### PR TITLE
[FIX] Fix trailing whitespace error in Hex MN configuration

### DIFF
--- a/org.epsg.openconfigurator/src/org/epsg/openconfigurator/builder/PowerlinkNetworkProjectBuilder.java
+++ b/org.epsg.openconfigurator/src/org/epsg/openconfigurator/builder/PowerlinkNetworkProjectBuilder.java
@@ -428,7 +428,9 @@ public class PowerlinkNetworkProjectBuilder extends IncrementalProjectBuilder {
                 sb.append(System.lineSeparator());
                 lineBreakCount = 0;
             } else {
-                sb.append(" "); //$NON-NLS-1$
+                if (cnt != (txtArray.length - 1)) {
+                    sb.append(" "); //$NON-NLS-1$
+                }
             }
         }
         sb.append("\n");


### PR DESCRIPTION
Fix issue reported in [pull request of openPOWERLINK](https://github.com/OpenAutomationTechnologies/openPOWERLINK_V2/pull/362)